### PR TITLE
Remove python27 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /logs/
 /lib/
 /_*/
+venv/
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ before_install:
     - sudo apt-get install zookeeper
     - sudo apt-get install zookeeperd
 
-    - wget https://github.com/coreos/etcd/releases/download/v0.4.6/etcd-v0.4.6-linux-amd64.tar.gz
-    - tar xvf etcd-v0.4.6-linux-amd64.tar.gz
-    - pushd etcd-v0.4.6-linux-amd64/
+    - wget https://github.com/coreos/etcd/releases/download/v3.4.8/etcd-v3.4.8-linux-amd64.tar.gz
+    - tar xvf etcd-v3.4.8-linux-amd64.tar.gz
+    - pushd etcd-v3.4.8-linux-amd64/
     - ./etcd &
     - popd
 
     - sudo apt-get install unzip
-    - wget https://dl.bintray.com/mitchellh/consul/0.4.1_linux_amd64.zip
-    - unzip 0.4.1_linux_amd64.zip
+    - wget https://releases.hashicorp.com/consul/1.7.3/consul_1.7.3_linux_amd64.zip
+    - unzip consul_1.7.3_linux_amd64.zip
     - ./consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul &
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: python
 
+sudo: required
+
+dist: bionic
+
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
 env:
     - TOXENV=py35
     - TOXENV=py36

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ python:
   - "3.7"
   - "3.8"
 
-env:
-    - TOXENV=py35
-    - TOXENV=py36
-    - TOXENV=py37
-    - TOXENV=py38
-    - TOXENV=lint
-
 before_install:
     - sudo apt-get update
     - sudo apt-get install zookeeper
@@ -34,7 +27,7 @@ before_install:
     - ./consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul &
 
 install:
-  - pip install tox
+  - pip install tox-travis
 
 script:
     - DISTCONFIG_RUN_INTEGRATION_TEST=true tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,17 @@ sudo: required
 
 dist: bionic
 
-python:
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "3.8"
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - env: TOXENV=lint
 
 before_install:
     - sudo apt-get update
@@ -27,7 +33,7 @@ before_install:
     - ./consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul &
 
 install:
-  - pip install tox-travis
+  - pip install tox
 
 script:
     - DISTCONFIG_RUN_INTEGRATION_TEST=true tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 
 env:
-    - TOXENV=py27
-    - TOXENV=py34
+    - TOXENV=py35
+    - TOXENV=py36
+    - TOXENV=py37
+    - TOXENV=py38
     - TOXENV=lint
 
 before_install:

--- a/README.rst
+++ b/README.rst
@@ -55,17 +55,17 @@ Example using zookeeper as a backend ::
     # config is a read only mapping-like object.
     config = proxy.get_config('/distconfig/service_name/config')
 
-    print config['key']
+    print(config['key'])
 
     # Getting nested values works by supplying key seperated by '/' char.
-    print config['key/inner']
+    print(config['key/inner'])
 
     # You can assert key value type by using typed get function e.g.
     # get_int, get_float, get_unicode, get_bytes ... .
-    print config.get_int('key/inner/int_key')
+    print(config.get_int('key/inner/int_key'))
 
     # Getting a inner config.
-    print config.get_config('key/inner/dict_key')
+    print(config.get_config('key/inner/dict_key'))
 
 
 Development:

--- a/distconfig/api.py
+++ b/distconfig/api.py
@@ -1,7 +1,7 @@
 from . import config, utils
 
 
-class Proxy(object):
+class Proxy:
     """Proxy class for differents backend."""
 
     def __init__(self, backend):

--- a/distconfig/backends/base.py
+++ b/distconfig/backends/base.py
@@ -1,16 +1,13 @@
 import abc
+import json
 import logging
 import sys
-
-import six
-import ujson
 
 
 LOGGER = logging.getLogger(__name__)
 
 
-@six.add_metaclass(abc.ABCMeta)
-class BaseBackend(object):
+class BaseBackend(metaclass=abc.ABCMeta):
     """Base abstract backend class.
 
     Backend implementation should inherit and implement ``get_raw`` method.
@@ -19,7 +16,7 @@ class BaseBackend(object):
     :param logger: :class:`logging.Logger`` instance.
     """
 
-    def __init__(self, parser=ujson.loads, logger=LOGGER):
+    def __init__(self, parser=json.loads, logger=LOGGER):
         self.__callbacks = []
         self.__parser = parser
 

--- a/distconfig/backends/etcd.py
+++ b/distconfig/backends/etcd.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from etcd import EtcdKeyNotFound
 
 from distconfig.backends.base import BaseBackend

--- a/distconfig/backends/execution_context.py
+++ b/distconfig/backends/execution_context.py
@@ -1,11 +1,8 @@
 import abc
 import threading
 
-import six
 
-
-@six.add_metaclass(abc.ABCMeta)
-class ExecutionContext(object):
+class ExecutionContext(metaclass=abc.ABCMeta):
     """Base abstract execution context class."""
 
     @abc.abstractmethod

--- a/distconfig/config.py
+++ b/distconfig/config.py
@@ -3,8 +3,6 @@ import functools
 import re
 import weakref
 
-import six
-
 
 UNDEFINED = object()
 
@@ -21,7 +19,7 @@ def _split_path(path, _regex=re.compile(r'(?<!\\)/')):
         ['', 'a', 'b', 'c']
         >>> _split_path('//')
         ['', '', '']
-        >>> _split_path('a\/b/c')
+        >>> _split_path('a\\/b/c')
         ['a/b', 'c']
 
     """
@@ -49,7 +47,7 @@ class Config(collections.Mapping):
 
     def _invalidate(self, new_data):
         self._data = new_data
-        for path, inner_config in six.iteritems(self.__inner_configs):
+        for path, inner_config in self.__inner_configs.items():
             inner_data = self.get(path, default={})
             inner_config._invalidate(inner_data)
 
@@ -75,7 +73,7 @@ class Config(collections.Mapping):
 
         ``path`` argument can be in the form 'key1/key2/key3' as a shortcut for doing
         ``config['key1']['key2']['key3']``. In case a key have a / in it, we can escape it
-        like so 'key1\/key2/key3' this will be translated to ``config['key1/key2']['key3']``
+        like so 'key1\\/key2/key3' this will be translated to ``config['key1/key2']['key3']``
 
         :param path: path expression e.g. 'key1/key2/key3'
         :param default: default value to return when key is missing, in case it's
@@ -157,19 +155,19 @@ class Config(collections.Mapping):
         """
         return self.get(path, default=default, type_=bool)
 
-    def get_unicode(self, path, default=UNDEFINED):
-        """Get path value as unicode.
+    def get_string(self, path, default=UNDEFINED):
+        """Get path value as string.
 
         :param path: path expression e.g. 'key1.key2.key3'
         :param default: default value to return when key is missing,
-            if supplied ``default`` must be of type unicode, default: UNDEFINED.
+            if supplied ``default`` must be of type ustring, default: UNDEFINED.
 
-        :return: the value of the requested path as a Unicode.
+        :return: the value of the requested path as a String.
 
         :raises TypeError: if path value is not of type ``type_``.
         :raises KeyError: if path doesn't exist and no default was given.
         """
-        return self.get(path, default=default, type_=six.text_type)
+        return self.get(path, default=default, type_=str)
 
     def get_bytes(self, path, default=UNDEFINED):
         """Get path value as bytes.
@@ -178,11 +176,11 @@ class Config(collections.Mapping):
         :param default: default value to return when key is missing,
             if supplied ``default`` must be of type bytes, default: UNDEFINED.
 
-        :return: the value of the requested path as a Unicode.
+        :return: the value of the requested path as Bytes.
 
         :raises TypeError: if path value is not of type ``type_``.
         :raises KeyError: if path doesn't exist and no default was given.
         """
-        return self.get(path, default=default, type_=six.binary_type)
+        return self.get(path, default=default, type_=bytes)
 
 

--- a/distconfig/tests/integration/base.py
+++ b/distconfig/tests/integration/base.py
@@ -4,15 +4,12 @@ import os
 import time
 import unittest
 
-import six
-
 envvar = 'DISTCONFIG_RUN_INTEGRATION_TEST'
 if os.environ.get(envvar) != 'true':
     raise unittest.SkipTest('Skipping integration tests, to enable run: export %s=true' % envvar)
 
 
-@six.add_metaclass(abc.ABCMeta)
-class _BackendTestCase(unittest.TestCase):
+class _BackendTestCase(unittest.TestCase, metaclass=abc.ABCMeta):
 
     def setUp(self):
         super(_BackendTestCase, self).setUp()
@@ -24,11 +21,13 @@ class _BackendTestCase(unittest.TestCase):
             'none': None
         }
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def path(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def proxy(self):
         pass
 

--- a/distconfig/tests/integration/test_consul_backend.py
+++ b/distconfig/tests/integration/test_consul_backend.py
@@ -1,9 +1,9 @@
+import http.client
 import os
 import socket
 import unittest
 
 import consul
-from six.moves import http_client
 
 from distconfig.tests.integration.base import _BackendTestCase
 from distconfig.api import Proxy
@@ -14,7 +14,7 @@ CONSUL_ENDPOINT_PORT = int(os.environ.get('CONSUL_ENDPOINT_PORT', 8500))
 
 
 def consul_running():
-    conn = http_client.HTTPConnection(CONSUL_ENDPOINT_IP, port=CONSUL_ENDPOINT_PORT)
+    conn = http.client.HTTPConnection(CONSUL_ENDPOINT_IP, port=CONSUL_ENDPOINT_PORT)
     try:
         conn.request('HEAD', '/')
     except (socket.error, socket.gaierror):

--- a/distconfig/tests/integration/test_etcd_backend.py
+++ b/distconfig/tests/integration/test_etcd_backend.py
@@ -1,9 +1,9 @@
+import http.client
 import os
 import socket
 import unittest
 
 import etcd
-from six.moves import http_client
 
 from distconfig.tests.integration.base import _BackendTestCase
 from distconfig.api import Proxy
@@ -15,7 +15,7 @@ ETCD_ENDPOINT_PORT = int(os.environ.get('ETCD_ENDPOINT_PORT', 4001))
 
 
 def etcd_running():
-    conn = http_client.HTTPConnection(ETCD_ENDPOINT_IP, port=ETCD_ENDPOINT_PORT)
+    conn = http.client.HTTPConnection(ETCD_ENDPOINT_IP, port=ETCD_ENDPOINT_PORT)
     try:
         conn.request('HEAD', '/')
     except (socket.error, socket.gaierror):

--- a/distconfig/tests/unit/test_config.py
+++ b/distconfig/tests/unit/test_config.py
@@ -1,6 +1,3 @@
-# -*- encoding: utf8 -*-
-import six
-
 import unittest
 
 from distconfig.config import Config
@@ -14,8 +11,8 @@ class ConfigTestCase(unittest.TestCase):
                 'integer': 1,
                 'float': 1.4,
                 'boolean': True,
-                'unicode': u'Straße',
-                'bytes': six.b('bytes')
+                'string': 'Straße',
+                'bytes': b'bytes'
             },
             'outer': 'foobar',
             'esca/ped': 'escaped'
@@ -37,7 +34,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(value, 'foobar')
 
     def test_get_escaped_key(self):
-        value = self.config.get('esca\/ped')
+        value = self.config.get('esca\\/ped')
         self.assertEqual(value, 'escaped')
 
     def test_no_key_exception(self):
@@ -51,7 +48,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(sorted(self.config), ['esca/ped', 'inner', 'outer'])
 
     def test_contains_path(self):
-        self.assertTrue('inner/unicode' in self.config)
+        self.assertTrue('inner/string' in self.config)
         self.assertTrue('outer' in self.config)
 
         self.assertTrue('inner/not_there' not in self.config)
@@ -113,28 +110,28 @@ class ConfigTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.config.get_boolean('inner/not_there', default='wrong type')
 
-    def test_get_unicode(self):
-        self.assertEqual(self.config.get_unicode('inner/unicode'), u'Straße')
+    def test_get_string(self):
+        self.assertEqual(self.config.get_string('inner/string'), 'Straße')
 
-    def test_get_unicode_with_default(self):
-        self.assertEqual(self.config.get_unicode('inner/not_there', default=u''), u'')
+    def test_get_string_with_default(self):
+        self.assertEqual(self.config.get_string('inner/not_there', default=''), '')
 
-    def test_get_unicode_wrong_type(self):
+    def test_get_string_wrong_type(self):
         with self.assertRaises(TypeError):
-            self.config.get_unicode('inner/integer')
+            self.config.get_string('inner/integer')
 
         with self.assertRaises(TypeError):
-            self.config.get_unicode('inner/not_there', default=1)
+            self.config.get_string('inner/not_there', default=1)
 
     def test_get_bytes(self):
-        self.assertEqual(self.config.get_bytes('inner/bytes'), six.b('bytes'))
+        self.assertEqual(self.config.get_bytes('inner/bytes'), b'bytes')
 
     def test_get_bytes_with_default(self):
-        self.assertEqual(self.config.get_bytes('inner/not_there', default=six.b('')), b'')
+        self.assertEqual(self.config.get_bytes('inner/not_there', default=b''), b'')
 
     def test_get_bytes_wrong_type(self):
         with self.assertRaises(TypeError):
-            self.config.get_bytes('inner/unicode')
+            self.config.get_bytes('inner/string')
 
         with self.assertRaises(TypeError):
             self.config.get_bytes('inner/not_there', default=1)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,0 @@
-six
-ujson

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ Sphinx
 tox
 mock
 coverage
-pyflake
+flake8
 kazoo
 python-etcd
 python-consul

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 from setuptools import setup, find_packages
 
 
@@ -11,33 +10,30 @@ setup(
     version='0.1.0',
     url='http://github.com/deliveryhero/distconfig/',
     packages=find_packages(),
-    author=u'© Deliver Hero Holding GmbH',
-    maintainer=u'Mouad Benchchaoui',
-    maintainer_email=u'mouad.benchchaoui@deliveryhero.com',
-    description=u'Library to manage configuration using Zookeeper, Etcd, Consul',
+    author='© Deliver Hero Holding GmbH',
+    maintainer='Mouad Benchchaoui',
+    maintainer_email='mouad.benchchaoui@deliveryhero.com',
+    description='Library to manage configuration using Zookeeper, Etcd, Consul',
     keywords='Configuration management zookeeper etcd consul',
     long_description=description,
     include_package_data=True,
-    install_requires=[
-        'six',
-        'ujson'
-    ],
+    install_requires=[],
     extras_require={
         'zookeeper': ['kazoo>=2.0'],
         'etcd': ['python-etcd>=0.3.3'],
         'consul': ['python-consul>=0.3.15'],
-        'gevent': ['gevent>=1.0.1'],
+        'gevent': ['gevent>=1.4.0'],
     },
     license='Apache License, Version 2.0',
     classifiers=[
         "Programming Language :: Python",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27,py34,lint
+envlist = py35,py36,py37,py38,lint
 
 [testenv]
 changedir = {envtmpdir}
 usedevelop=True
 commands = nosetests --with-coverage --cover-erase --cover-package=distconfig --with-doctest --logging-level=ERROR --nocapture --nologcapture --verbose distconfig []
 deps =
-    -rrequirements/base.txt
     -rrequirements/dev.txt
 
 [testenv:docs]
@@ -17,6 +16,6 @@ commands =
 
 [testenv:lint]
 deps =
-   pyflake
+   flake8
 commands=
    flake8 {toxinidir}/distconfig

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,lint
+envlist = py{35,36,37,38},lint
 
 [testenv]
 changedir = {envtmpdir}


### PR DESCRIPTION
Hello,

This hasn't been updated in five years, but I'll try my luck. 

This PR removes support for Python 2.7 as well as `six` and `ujson` requirements. `six` is obviously not needed since Python 2.7 support was removed and I am not sure why `ujson` was included since it's possible to pass the parser of our choice to the backend via `Proxy().configure()`. Another notable change is the renaming of `Config()` `get_unicode()` to `get_string()` since the former doesn't make much sense anymore on Python 3.x.